### PR TITLE
Better Announcements

### DIFF
--- a/Batbot.csproj
+++ b/Batbot.csproj
@@ -208,6 +208,7 @@
   <ItemGroup>
     <Compile Include="AddModule.cs" />
     <Compile Include="Commands.cs" />
+    <Compile Include="CooldownModule.cs" />
     <Compile Include="Data.cs" />
     <Compile Include="Debug.cs" />
     <Compile Include="HelpModule.cs" />

--- a/Commands.cs
+++ b/Commands.cs
@@ -32,12 +32,16 @@ namespace Batbot{
 				"!reset [twitch-user-id] - Resets the name for a particular UserID in the list"
 			}},
 
+			{ "setcooldown", new List<string>{
+				"!setcooldown [hours] - Sets how long I should wait before being able to announce the same streamer again"
+			}},
+
 			{ "setchannel", new List<string>{
 				"!setchannel [#discord-chanel] - Adds or removes Discord channels for streams to be announced in"
 			}},
 
-			{ "updatefrequency", new List<string>{
-				"!updatefrequency [minutes] - Sets how often new streams will be checked for"
+			{ "setupdatefrequency", new List<string>{
+				"!setupdatefrequency [minutes] - Sets how often new streams will be checked for"
 			}}
 		};
 

--- a/CooldownModule.cs
+++ b/CooldownModule.cs
@@ -1,0 +1,35 @@
+﻿using System.Threading.Tasks;
+
+using Discord.Commands;
+
+namespace Batbot{
+	class CooldownModule : ModuleBase<SocketCommandContext>{
+		[Command("setcooldown")]
+		[Summary("Sets how long I should wait before being able to announce the same streamer again")]
+		public Task SetChannelAsync(){
+			Context.Message.AddReactionAsync(new Discord.Emoji("👎"));
+			return ReplyAsync("```\n" + Commands.GenerateCommandText("setcooldown") + "```");
+		}
+
+		[Command("setcooldown")]
+		[Summary("Sets how long I should wait before being able to announce the same streamer again")]
+		public Task SetChannelAsync(string _){
+			Context.Message.AddReactionAsync(new Discord.Emoji("👎"));
+			return ReplyAsync("```\n" + Commands.GenerateCommandText("setcooldown") + "```");
+		}
+
+		[Command("setcooldown")]
+		[Summary("Sets how long I should wait before being able to announce the same streamer again")]
+		public Task SetChannelAsync([Remainder] [Summary("The text to echo")] float cooldown){
+			Context.Message.AddReactionAsync(new Discord.Emoji("👍"));
+
+			if(cooldown < 0.0f){
+				return ReplyAsync("Cooldown must be a positive value!");
+			}
+
+			Data.Cooldown = cooldown;
+			Data.Save();
+			return ReplyAsync("Success - I will now wait " + cooldown + " hour(s) before announcing the same streamer again");
+		}
+	}
+}

--- a/Data.cs
+++ b/Data.cs
@@ -11,6 +11,7 @@ namespace Batbot{
 		private static readonly string channelsFile = "Data/Channels.txt";
 		private static readonly string announcedStreamsFile = "Data/AnnouncedStreams.txt";
 		private static readonly string updateFrequencyFile = "Data/UpdateFrequency.txt";
+		private static readonly string cooldownFile = "Data/Cooldown.txt";
 		private static readonly string announceMessagesFile = "Data/AnnounceMessages.txt";
 		private static readonly string reactionRoleFile = "Data/ReactionRoles.json";
 
@@ -20,6 +21,7 @@ namespace Batbot{
 		private static List<ulong> _channels = new List<ulong>();
 		private static List<string> _announcedStreams = new List<string>();
 		private static volatile float _updateFrequency = 0.0f;
+		private static volatile float _cooldown = 0.0f;
 		private static List<string> _announceMessages = new List<string>();
 		private static List<ReactionRole> _reactionRoles = new List<ReactionRole>();
 
@@ -51,6 +53,11 @@ namespace Batbot{
 		public static float UpdateFrequency{
 			get{ return _updateFrequency; }
 			set{ _updateFrequency = value; Save(); }
+		}
+
+		public static float Cooldown{
+			get{ return _cooldown; }
+			set{ _cooldown = value; Save(); }
 		}
 
 		public static List<string> AnnounceMessages{
@@ -85,6 +92,12 @@ namespace Batbot{
 				_updateFrequency = 5.0f;
 			}
 
+			if(float.TryParse(System.IO.File.ReadAllText(cooldownFile), out float c)){
+				_cooldown = c;
+			}else{
+				_cooldown = 1.0f;
+			}
+
 			lock(_streamers){
 				_streamers = JsonConvert.DeserializeObject<Dictionary<string, string>>(System.IO.File.ReadAllText(streamersFile));
 				if(_streamers == null){
@@ -113,6 +126,7 @@ namespace Batbot{
 			}
 
 			System.IO.File.WriteAllText(updateFrequencyFile, _updateFrequency.ToString());
+			System.IO.File.WriteAllText(cooldownFile, _cooldown.ToString());
 
 			SerializeRoles();
 		}

--- a/Program.cs
+++ b/Program.cs
@@ -23,10 +23,12 @@ namespace Batbot {
 			return value;
 		}
 
-		void ApplyCooldown(string twitchID){
+		void ApplyCooldown(string twitchID, string name){
+			Debug.Log("Placing " + name + " [" + twitchID + "] on cooldown...", Debug.Verbosity.Verbose);
 			lock(streamersOnCooldown) streamersOnCooldown.Add(twitchID);
 			System.Threading.Thread.Sleep((int)(1000.0f * 60.0f * 60.0f * Data.Cooldown)); //Wait [cooldown] hours
 			lock(streamersOnCooldown) streamersOnCooldown.Remove(twitchID);
+			Debug.Log(name + " [" + twitchID + "] removed from cooldown", Debug.Verbosity.Verbose);
 		}
 
 		[DllImport("Kernel32")]
@@ -321,7 +323,7 @@ namespace Batbot {
 
 			var gameName = Twitch.gameIDs.FirstOrDefault(x => x.Value == ts.gameID).Key;
 			Debug.Log(ts.user + " is live with " + gameName);
-			Task.Run(() => ApplyCooldown(ts.userID));
+			Task.Run(() => ApplyCooldown(ts.userID, ts.user));
 			foreach(ulong c in Data.Channels){
 				var announceChannel = _client.GetChannel(c) as SocketTextChannel;
 				await announceChannel.SendMessageAsync(FormatAnnouncementMessage(ts.user, gameName, ts.title));

--- a/Program.cs
+++ b/Program.cs
@@ -93,6 +93,7 @@ namespace Batbot {
 
 			await _commands.AddModulesAsync(assembly: Assembly.GetEntryAssembly(), services: null);
 			await _commands.AddModuleAsync<AddModule>(null);
+			await _commands.AddModuleAsync<CooldownModule>(null);
 			await _commands.AddModuleAsync<HelpModule>(null);
 			await _commands.AddModuleAsync<ListModule>(null);
 			await _commands.AddModuleAsync<MessageModule>(null);

--- a/Program.cs
+++ b/Program.cs
@@ -25,7 +25,7 @@ namespace Batbot {
 
 		void ApplyCooldown(string twitchID){
 			lock(streamersOnCooldown) streamersOnCooldown.Add(twitchID);
-			System.Threading.Thread.Sleep(1000 * 60 * 60); //Wait one hour, TODO - Custom cooldown duration
+			System.Threading.Thread.Sleep((int)(1000.0f * 60.0f * 60.0f * Data.Cooldown)); //Wait [cooldown] hours
 			lock(streamersOnCooldown) streamersOnCooldown.Remove(twitchID);
 		}
 
@@ -169,7 +169,7 @@ namespace Batbot {
 			int iterations = 0;
 			while(true){
 				if(iterations > 0){
-					System.Threading.Thread.Sleep((int)(1000 * 60 * Data.UpdateFrequency)); //Every [updateFrequency] minutes
+					System.Threading.Thread.Sleep((int)(1000.0f * 60.0f * Data.UpdateFrequency)); //Every [updateFrequency] minutes
 				}
 
 				Debug.Log("Checking for new streams to announce...", Debug.Verbosity.Verbose);

--- a/Program.cs
+++ b/Program.cs
@@ -321,7 +321,7 @@ namespace Batbot {
 
 			var gameName = Twitch.gameIDs.FirstOrDefault(x => x.Value == ts.gameID).Key;
 			Debug.Log(ts.user + " is live with " + gameName);
-			ApplyCooldown(ts.userID);
+			Task.Run(() => ApplyCooldown(ts.userID));
 			foreach(ulong c in Data.Channels){
 				var announceChannel = _client.GetChannel(c) as SocketTextChannel;
 				await announceChannel.SendMessageAsync(FormatAnnouncementMessage(ts.user, gameName, ts.title));

--- a/Program.cs
+++ b/Program.cs
@@ -169,19 +169,23 @@ namespace Batbot{
 				foreach(TwitchStream ts in streams){
 					lock(Data.AnnouncedStreams){
 						if(Data.AnnouncedStreams.Contains(ts.id)){
-							if(Twitch.gameIDs.ContainsValue(ts.gameID)){
-								streamsAnnounced++; //Only count towards the total if it's still a Batman stream
+							if(Twitch.gameIDs.ContainsValue(ts.gameID) && !ts.title.Contains("[nosrl]")){
+								streamsAnnounced++; //Only count towards the total if it's still a Batman speedrunning stream
 							}
 							
 							continue; //We've already announced this stream
 						}
 					}
 
-					if(Twitch.gameIDs.ContainsValue(ts.gameID)){
+					if(Twitch.gameIDs.ContainsValue(ts.gameID) && !ts.title.Contains("[nosrl]")){
 						streamsAnnounced++;
 						await AnnounceStream(ts);
 					}else{
 						if(!loggedStreams.Contains(ts.id)){
+							if(ts.title.Contains("[nosrl]")){
+								Debug.Log(ts.user + " is streaming non-speedrunning content, ignoring...");
+							}
+
 							Debug.Log(ts.user + " is streaming a non-Batman game, ignoring...");
 							loggedStreams.Add(ts.id);
 						}


### PR DESCRIPTION
**Issues:**
-Non-speedrunning streams are often announced
-When a streamer briefly disconnects from Twitch and restarts their stream, a new announcement is sent. This can result in the bot posting many announcements for one channel in quick succession (worst case I've seen is 3 within a minute of each other).

**Solutions:**
-Streams with [nosrl] in the title will be ignored. Many other sites and services that monitor speedrunning streams rely on this convention. This of course requires streamers to actually follow this convention (which they frequently do not), but it's better than nothing.
-Once a stream is announced, that streamer is placed on a "cooldown" for a period of time (one hour by default, can be changed with the !setcooldown command). While the cooldown is in effect, any new streams by that streamer will be ignored.

**Testing:**
Requires further testing to ensure correct functionality and long-term stability. Will continue to monitor the test environment and update any necessary.